### PR TITLE
Fix missing null terminator in ecryptfs auth token

### DIFF
--- a/security/keys/encrypted-keys/ecryptfs_format.c
+++ b/security/keys/encrypted-keys/ecryptfs_format.c
@@ -56,6 +56,8 @@ int ecryptfs_fill_auth_tok(struct ecryptfs_auth_tok *auth_tok,
 	auth_tok->token_type = ECRYPTFS_PASSWORD;
 	strncpy((char *)auth_tok->token.password.signature, key_desc,
 		ECRYPTFS_PASSWORD_SIG_SIZE);
+	/* Ensure signature string is null terminated as strncpy may not */
+	auth_tok->token.password.signature[ECRYPTFS_PASSWORD_SIG_SIZE] = '\0';
 	auth_tok->token.password.session_key_encryption_key_bytes =
 		ECRYPTFS_MAX_KEY_BYTES;
 	/*


### PR DESCRIPTION
## Summary
- ensure the password signature buffer is null terminated

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6843607da92883338381f10dfdc351af